### PR TITLE
fin: toggle hub twice to make flashing consistant

### DIFF
--- a/lib/devices.ts
+++ b/lib/devices.ts
@@ -203,6 +203,10 @@ export class BalenaFin extends DeviceInteractor {
 	// usb-toggle
 	async toggleUsb(state: boolean, port: number) {
 		console.log(`Toggling USB ${state ? 'on' : 'off'}`);
+		// we will do this twice, as there could be issues with the driver that cause the hub to re-power the device (https://github.com/balena-io-hardware/balena-fulfillment-rig/blob/master/core/app/utils/dut-power/index.js#L26)
+		await exec(
+			`${this.OUTPUT_DIR}uhubctl -a ${state ? 'on' : 'off'} -p ${port} -l 1-1`,
+		);
 		await exec(
 			`${this.OUTPUT_DIR}uhubctl -a ${state ? 'on' : 'off'} -p ${port} -l 1-1`,
 		);


### PR DESCRIPTION
We have had problems with the flashing of balena fins using the deviceInteractor. We have tried to isolate the problem to no effect.

When looking at the fin fullfillment rig code I saw this: https://github.com/balena-io-hardware/balena-fulfillment-rig/blob/master/core/app/utils/dut-power/index.js#L26

If it's true, and the usb hub driver doesn't always respect the uhubctl commands, doubling up the commands might help. This was the only difference I could find between the fin flashing procedure in the testbotsdk and the fin-fulfillment rig (software) - and the fulfillment rig never seems to have the problem. So hopefully this will help!

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>