### PR TITLE
lib/devices: Check current on iMX8MM-VAR-DART-NRT

### DIFF
--- a/lib/devices.ts
+++ b/lib/devices.ts
@@ -311,6 +311,18 @@ export class Imx8mmVarDartNRT extends FlasherDeviceInteractor {
 	constructor(testBot: TestBot) {
 		super(testBot, 5);
 	}
+
+	async checkDutPower() {
+		const outCurrent = await this.testBot.readVoutAmperage();
+		console.log(`Out current is: ` + outCurrent);
+		if (outCurrent > 0.03) {
+			console.log(`Imx8mmVarDartNRT is currently On`);
+			return true;
+		} else {
+			console.log(`Imx8mmVarDartNRT is currently Off`);
+			return false;
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
This DT does not have any USB or ETH ports so
we can only rely on out current to determine
when it finished flashing.

Signed-off-by: Alexandru Costache <alexandru@balena.io>